### PR TITLE
Cause text in session activity to wrap

### DIFF
--- a/HTMLReport/preview.css
+++ b/HTMLReport/preview.css
@@ -2,6 +2,11 @@ body{
     min-width: 40%;
     max-width: 100%; 
 }
+
+td {
+    white-space: normal;
+}
+
 #sessionInfo {
     font-size: 0.7rem;
 }
@@ -27,6 +32,7 @@ img{
 
 #sessionActivityTable.tr {
     vertical-align: top;
+    table-layout: fixed;
 }
 
 .annotationDescription, .annotationUrl {

--- a/HTMLReport/preview.css
+++ b/HTMLReport/preview.css
@@ -32,7 +32,6 @@ img{
 
 #sessionActivityTable.tr {
     vertical-align: top;
-    table-layout: fixed;
 }
 
 .annotationDescription, .annotationUrl {


### PR DESCRIPTION
The text in the session activity table doesn't wrap, so you have to scroll sideways for a long time if your notes are long. This little CSS change should fix the issue.