### PR TITLE
Add GitHub Actions CI pipeline for unit and e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e:ci
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2478,7 +2477,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:e2e:debug": "playwright test smoke.spec.js basic-functionality.spec.js --debug",
     "test:e2e:report": "playwright show-report",
     "test:e2e:crop": "playwright test crop-screenshot.spec.js --headed",
+    "test:e2e:ci": "playwright test smoke.spec.js basic-functionality.spec.js reports-export.spec.js crop-screenshot.spec.js",
     "test:all": "npm test && npm run test:e2e"
   },
   "repository": {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,6 +2,9 @@
 const { defineConfig, devices } = require('@playwright/test');
 const path = require('path');
 
+const isCI = !!process.env.CI;
+const isWindows = process.platform === 'win32';
+
 /**
  * Playwright configuration for Chrome Extension E2E testing
  * @see https://playwright.dev/docs/test-configuration
@@ -14,9 +17,9 @@ module.exports = defineConfig({
 
   // Test execution settings
   fullyParallel: false, // Extensions can't run fully parallel easily
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : 1, // Run tests sequentially for extensions
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: 1, // Run tests sequentially for extensions
 
   // Reporter to use
   reporter: [
@@ -48,8 +51,8 @@ module.exports = defineConfig({
       name: 'chromium-extension',
       use: {
         ...devices['Desktop Chrome'],
-        // Edge has the best extension support with Playwright
-        channel: 'msedge', // Use Microsoft Edge - works best with extensions
+        // In CI (Linux), use plain chromium; locally on Windows/macOS use msedge
+        ...(isCI ? {} : { channel: 'msedge' }),
         // Note: Extension loading happens in test setup via helper functions
       },
     },
@@ -57,9 +60,11 @@ module.exports = defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'powershell -File ./start_test_server.ps1',
+    command: isWindows
+      ? 'powershell -File ./start_test_server.ps1'
+      : 'python3 -m http.server 8000',
     url: 'http://localhost:8000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !isCI,
     timeout: 10 * 1000,
   },
 });


### PR DESCRIPTION
- Add .github/workflows/ci.yml with two jobs: unit tests (Jest) and
  e2e tests (Playwright), triggered on every push and pull request
- Update playwright.config.js for cross-platform CI compatibility:
  use plain chromium instead of msedge in CI, and python3 http server
  instead of PowerShell on non-Windows systems
- Add test:e2e:ci npm script to run all e2e test suites

Note: 4 pre-existing unit test failures exist in JSonSessionService.test.js
(BrowserInfo object vs string mismatch).

https://claude.ai/code/session_0112Ugwyx6RHkNhqW1bgSErN